### PR TITLE
Fix isValidClosureName to handle generic types correctly.

### DIFF
--- a/SourceryRuntime/Sources/Extensions.swift
+++ b/SourceryRuntime/Sources/Extensions.swift
@@ -96,7 +96,7 @@ public extension String {
 
     /// :nodoc:
     func isValidClosureName() -> Bool {
-        return components(separatedBy: "->", excludingDelimiterBetween: ("(", ")")).count > 1
+        return components(separatedBy: "->", excludingDelimiterBetween: (["(", "<"], [")", ">"])).count > 1
     }
 
     /// :nodoc:
@@ -139,7 +139,6 @@ public extension String {
         var quotesCount: Int = 0
         var item = ""
         var items = [String]()
-        var matchedDelimiter = (alreadyMatched: "", leftToMatch: delimiter)
 
         var i = self.startIndex
         while i < self.endIndex {

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -1967,7 +1967,7 @@ public extension String {
 
     /// :nodoc:
     func isValidClosureName() -> Bool {
-        return components(separatedBy: "->", excludingDelimiterBetween: ("(", ")")).count > 1
+        return components(separatedBy: "->", excludingDelimiterBetween: (["(", "<"], [")", ">"])).count > 1
     }
 
     /// :nodoc:
@@ -2010,7 +2010,6 @@ public extension String {
         var quotesCount: Int = 0
         var item = ""
         var items = [String]()
-        var matchedDelimiter = (alreadyMatched: "", leftToMatch: delimiter)
 
         var i = self.startIndex
         while i < self.endIndex {

--- a/SourceryTests/Models/TypeNameSpec.swift
+++ b/SourceryTests/Models/TypeNameSpec.swift
@@ -111,7 +111,20 @@ class TypeNameSpec: QuickSpec {
                     expect(TypeName("() -> (Int, Int)").isClosure).to(beTrue())
                     expect(TypeName("() -> (Int) -> (Int)").isClosure).to(beTrue())
                     expect(TypeName("((Int) -> (Int)) -> ()").isClosure).to(beTrue())
+                    expect(TypeName("(Foo<String>) -> Bool)").isClosure).to(beTrue())
+                    expect(TypeName("(Int) -> Foo<Bool>").isClosure).to(beTrue())
+                    expect(TypeName("(Foo<String>) -> Foo<Bool>)").isClosure).to(beTrue())
                     expect(TypeName("((Int, Int) -> (), Int)").isClosure).to(beFalse())
+                }
+            }
+
+            context("given closure type inside generic type") {
+                it("reports closure correctly") {
+                    expect(TypeName("Foo<() -> ()>").isClosure).to(beFalse())
+                    expect(TypeName("Foo<(String) -> Bool>").isClosure).to(beFalse())
+                    expect(TypeName("Foo<(String) -> Bool?>").isClosure).to(beFalse())
+                    expect(TypeName("Foo<(Bar<String>) -> Bool)>").isClosure).to(beFalse())
+                    expect(TypeName("Foo<(Bar<String>) -> Bar<Bool>)>").isClosure).to(beFalse())
                 }
             }
 


### PR DESCRIPTION
Fix isValidClosureName to handle generic types correctly.